### PR TITLE
ShutdownThread: Decrypt before stopping storage manager

### DIFF
--- a/services/core/java/com/android/server/power/ShutdownThread.java
+++ b/services/core/java/com/android/server/power/ShutdownThread.java
@@ -630,6 +630,13 @@ public final class ShutdownThread extends Thread {
             }
         };
 
+        if (mRebootUpdate) {
+            sInstance.setRebootProgress(MOUNT_SERVICE_STOP_PERCENT, null);
+
+            // If it's to reboot to install update, invoke uncrypt via init service.
+            uncrypt();
+        }
+
         Log.i(TAG, "Shutting down MountService");
 
         // Set initial variables and time out time.
@@ -664,12 +671,6 @@ public final class ShutdownThread extends Thread {
                 } catch (InterruptedException e) {
                 }
             }
-        }
-        if (mRebootUpdate) {
-            sInstance.setRebootProgress(MOUNT_SERVICE_STOP_PERCENT, null);
-
-            // If it's to reboot to install update, invoke uncrypt via init service.
-            uncrypt();
         }
 
         rebootOrShutdown(mContext, mReboot, mRebootReason);


### PR DESCRIPTION
uncrypt needs access to the file to uncrypt it.  If we stop the
storage manager service, uncrypting fails, leading to failed
updates.

Change-Id: Ifc75c990ebf8f0a2f11b340cd39cd469b46c6f68